### PR TITLE
Hermes select rereviewer

### DIFF
--- a/backend/src/main/kotlin/com/hootsuite/hermes/github/GithubEventHandler.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/github/GithubEventHandler.kt
@@ -90,20 +90,21 @@ object GithubEventHandler {
         val commentBody = issueCommentEvent.comment.body.trim()
         if (issueCommentEvent.action == IssueCommentAction.CREATED && commentBody.startsWith(Config.REREVIEW)) {
             val argumentList = commentBody.split(' ').drop(1)
+            val issueUrl = issueCommentEvent.issue.htmlUrl
             when {
-                commentBody == Config.REREVIEW -> DatabaseUtils.getRereviewers(issueCommentEvent.issue.htmlUrl).forEach {
+                commentBody == Config.REREVIEW -> DatabaseUtils.getRereviewers(issueUrl).forEach {
                     SlackMessageHandler.rerequestReviewer(
                         reviewer = it,
-                        author = issueCommentEvent.issue.user.login,
-                        url = issueCommentEvent.issue.htmlUrl
+                        author = issueCommentEvent.comment.user.login,
+                        url = issueUrl
                     )
                 }
                 argumentList.all { it.startsWith('@') } -> {
                     argumentList.mapNotNull { DatabaseUtils.getSlackUserOrNull(it.removePrefix("@")) }.forEach {
                         SlackMessageHandler.rerequestReviewer(
                             reviewer = it,
-                            author = issueCommentEvent.issue.user.login,
-                            url = issueCommentEvent.issue.htmlUrl
+                            author = issueCommentEvent.comment.user.login,
+                            url = issueUrl
                         )
                     }
                 }

--- a/backend/src/main/kotlin/com/hootsuite/hermes/github/GithubEventHandler.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/github/GithubEventHandler.kt
@@ -89,7 +89,7 @@ object GithubEventHandler {
     fun issueComment(issueCommentEvent: IssueCommentEvent) {
         val commentBody = issueCommentEvent.comment.body.trim()
         if (issueCommentEvent.action == IssueCommentAction.CREATED && commentBody.startsWith(Config.REREVIEW)) {
-            val argumentList = commentBody.split(' ').drop(0)
+            val argumentList = commentBody.split(' ').drop(1)
             when {
                 commentBody == Config.REREVIEW -> DatabaseUtils.getRereviewers(issueCommentEvent.issue.htmlUrl).forEach {
                     SlackMessageHandler.rerequestReviewer(

--- a/backend/src/main/kotlin/com/hootsuite/hermes/github/GithubEventHandler.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/github/GithubEventHandler.kt
@@ -99,7 +99,7 @@ object GithubEventHandler {
                     )
                 }
                 argumentList.all { it.startsWith('@') } -> {
-                    argumentList.mapNotNull { DatabaseUtils.getSlackUserOrNull(it) }.forEach {
+                    argumentList.mapNotNull { DatabaseUtils.getSlackUserOrNull(it.removePrefix("@")) }.forEach {
                         SlackMessageHandler.rerequestReviewer(
                             reviewer = it,
                             author = issueCommentEvent.issue.user.login,

--- a/backend/src/main/kotlin/com/hootsuite/hermes/github/GithubEventHandler.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/github/GithubEventHandler.kt
@@ -87,15 +87,26 @@ object GithubEventHandler {
      * @param issueCommentEvent - The Event from the Github Webhook
      */
     fun issueComment(issueCommentEvent: IssueCommentEvent) {
-        if (issueCommentEvent.action == IssueCommentAction.CREATED &&
-            issueCommentEvent.comment.body == Config.REREVIEW
-        ) {
-            DatabaseUtils.getRereviewers(issueCommentEvent.issue.htmlUrl).forEach {
-                SlackMessageHandler.rerequestReviewer(
-                    reviewer = it,
-                    author = issueCommentEvent.issue.user.login,
-                    url = issueCommentEvent.issue.htmlUrl
-                )
+        val commentBody = issueCommentEvent.comment.body.trim()
+        if (issueCommentEvent.action == IssueCommentAction.CREATED && commentBody.startsWith(Config.REREVIEW)) {
+            val argumentList = commentBody.split(' ').drop(0)
+            when {
+                commentBody == Config.REREVIEW -> DatabaseUtils.getRereviewers(issueCommentEvent.issue.htmlUrl).forEach {
+                    SlackMessageHandler.rerequestReviewer(
+                        reviewer = it,
+                        author = issueCommentEvent.issue.user.login,
+                        url = issueCommentEvent.issue.htmlUrl
+                    )
+                }
+                argumentList.all { it.startsWith('@') } -> {
+                    argumentList.mapNotNull { DatabaseUtils.getSlackUserOrNull(it) }.forEach {
+                        SlackMessageHandler.rerequestReviewer(
+                            reviewer = it,
+                            author = issueCommentEvent.issue.user.login,
+                            url = issueCommentEvent.issue.htmlUrl
+                        )
+                    }
+                }
             }
         } else {
             // TODO Handle Other Actions?

--- a/backend/src/main/kotlin/com/hootsuite/hermes/github/model/Payloads.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/github/model/Payloads.kt
@@ -7,7 +7,8 @@ import java.util.Arrays
  * Github Comment Model Object
  */
 data class Comment(
-    val body: String
+    val body: String,
+    val user: User
 )
 
 /**


### PR DESCRIPTION
Allow the user to add a specific person to look again at a PR by adding a space delimited list of github names (including the '@').

Example: 
```
!hermes @neil-power-hs
```
as a top level comment on a Hermes watched PR would now notify me in my chosen slack channel to look again at a PR.