### PR TITLE
Adding rejected and unapproved lists to the rereview command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ These are some features which are planned to be added to Hermes.
 * Track the mean time to resolution for pull requests.
 * Better front-end interface for registering users
 * Allow the user to toggle on or off notifications
-* Control the rereview messages to be for all reviewers, only those who haven't looked, or only those who have requested changes.
-* Remove Teams and Users
+* Remove Teams and Users through a UI
 * Tests!
 * Messaging the user who configured a webhook if possible when the webhook is misconfigured.
 * Subscribe to specific hermes events.
 * Control your hermes subscription through slack.
-* Add an avatar when a user is registered to display in slack.
 * Track reviewers who add themselves to a PR
+* Change formatting of messages to be more compact
+* Add slash commands for help
 
 ## <a name="TOC-Future"></a>License ##
 

--- a/backend/src/main/kotlin/com/hootsuite/hermes/Config.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/Config.kt
@@ -24,22 +24,22 @@ object Config {
 
     // TODO We should only need one of these, either register admin channel or configure via file
     // Admin slack webhook to send Hermes status messages to
-    var SLACK_ADMIN_URL: String = configData.adminUrl
+    var ADMIN_URL = configData.adminUrl
 
     // Admin Channel to send Hermes Status messages to
-    val ADMIN_CHANNEL: String = configData.adminChannel ?: "#hermes-admin"
+    val ADMIN_CHANNEL = configData.adminChannel ?: "#hermes-admin"
 
     // Port for the Server to run on
-    val SERVER_PORT: Int = configData.serverPort ?: 8080
+    val SERVER_PORT = configData.serverPort ?: 8080
 
     // Trigger Comment for sending review request updates
-    val REREVIEW: String = configData.rereview?.command ?: "!hermes"
+    val REREVIEW = configData.rereview?.command ?: "!hermes"
 
     // Parameter passed to rereview command to only notify people who have requested changes to the pull request
-    val REJECTED: String = configData.rereview?.rejected ?: "rejected"
+    val REJECTED = configData.rereview?.rejected ?: "rejected"
 
     // Parameter passed to rereview command to only notify people who have not approved the pull request
-    val UNAPPROVED: String = configData.rereview?.unapproved ?: "unapproved"
+    val UNAPPROVED = configData.rereview?.unapproved ?: "unapproved"
 
     /**
      * Supported Endpoints
@@ -71,7 +71,7 @@ object Config {
  */
 data class ConfigData(
     val adminUrl: String,
-    val serverPort: Int? =null,
+    val serverPort: Int? = null,
     val adminChannel: String? = null,
     val rereview: RereviewCommand? = null
 )

--- a/backend/src/main/kotlin/com/hootsuite/hermes/Config.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/Config.kt
@@ -24,15 +24,22 @@ object Config {
 
     // TODO We should only need one of these, either register admin channel or configure via file
     // Admin slack webhook to send Hermes status messages to
-    var SLACK_ADMIN_URL = configData.adminUrl
+    var SLACK_ADMIN_URL: String = configData.adminUrl
+
     // Admin Channel to send Hermes Status messages to
-    val ADMIN_CHANNEL = configData.adminChannel
+    val ADMIN_CHANNEL: String = configData.adminChannel ?: "#hermes-admin"
 
     // Port for the Server to run on
-    val SERVER_PORT = configData.serverPort
+    val SERVER_PORT: Int = configData.serverPort ?: 8080
 
     // Trigger Comment for sending review request updates
-    val REREVIEW = configData.rereviewCommand
+    val REREVIEW: String = configData.rereview?.command ?: "!hermes"
+
+    // Parameter passed to rereview command to only notify people who have requested changes to the pull request
+    val REJECTED: String = configData.rereview?.rejected ?: "rejected"
+
+    // Parameter passed to rereview command to only notify people who have not approved the pull request
+    val UNAPPROVED: String = configData.rereview?.unapproved ?: "unapproved"
 
     /**
      * Supported Endpoints
@@ -45,6 +52,7 @@ object Config {
         const val TEAMS = "/teams"
         const val REGISTER_TEAM = "/registerTeam"
         const val REVIEW_REQUESTS = "/reviewRequests"
+        const val REVIEWS = "/reviews"
         const val INSTALL = "/install"
     }
 
@@ -63,9 +71,15 @@ object Config {
  */
 data class ConfigData(
     val adminUrl: String,
-    val serverPort: Int,
-    val adminChannel: String,
-    val rereviewCommand: String
+    val serverPort: Int? =null,
+    val adminChannel: String? = null,
+    val rereview: RereviewCommand? = null
+)
+
+data class RereviewCommand(
+    val command: String? = null,
+    val rejected: String? = null,
+    val unapproved: String? = null
 )
 
 /**

--- a/backend/src/main/kotlin/com/hootsuite/hermes/Main.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/Main.kt
@@ -3,6 +3,7 @@ package com.hootsuite.hermes
 import com.github.kittinunf.fuel.gson.responseObject
 import com.github.kittinunf.fuel.httpGet
 import com.hootsuite.hermes.database.DatabaseUtils
+import com.hootsuite.hermes.database.model.ReviewEntity
 import com.hootsuite.hermes.database.model.ReviewRequestEntity
 import com.hootsuite.hermes.database.model.TeamEntity
 import com.hootsuite.hermes.database.model.UserEntity
@@ -77,6 +78,9 @@ fun main(args: Array<String>) {
 
             // ReviewRequests
             get(Config.Endpoint.REVIEW_REQUESTS) { reviewRequestsGet(call) }
+
+            //Reviews
+            get(Config.Endpoint.REVIEWS) { reviewsGet(call) }
 
             // Install Slack App
             get(Config.Endpoint.INSTALL) { installGet(call) }
@@ -215,6 +219,20 @@ suspend fun reviewRequestsGet(call: ApplicationCall) {
 }
 
 /**
+ * Handle the GET to the /reviews Endpoint
+ * @param call - The ApplicationCall of the request
+ * TODO For Testing only
+ */
+suspend fun reviewsGet(call: ApplicationCall) {
+    val reviews = transaction { ReviewEntity.all().joinToString("<br>") { it.toString() } }
+    val reviewsHtml = StringBuilder()
+    reviewsHtml.append("<h1>Review Requests</h1><p>")
+    reviewsHtml.append(reviews)
+    reviewsHtml.append("</p>")
+    call.respondText(reviewsHtml.toString(), ContentType.Text.Html, HttpStatusCode.OK)
+}
+
+/**
  * Hande the GET to the /install Endpoint. Auth the app with a specific slack channel and store that as a team in the db
  * @param call - The ApplicationCall of the request
  */
@@ -235,7 +253,7 @@ suspend fun installGet(call: ApplicationCall) {
                     webhook.url,
                     config.serverPort,
                     config.adminChannel,
-                    config.rereviewCommand
+                    config.rereview
                 )
                 call.respondText("Admin Channel Registered", ContentType.Text.Plain, HttpStatusCode.OK)
             } else {

--- a/backend/src/main/kotlin/com/hootsuite/hermes/Main.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/Main.kt
@@ -225,11 +225,11 @@ suspend fun reviewRequestsGet(call: ApplicationCall) {
  */
 suspend fun reviewsGet(call: ApplicationCall) {
     val reviews = transaction { ReviewEntity.all().joinToString("<br>") { it.toString() } }
-    val reviewsHtml = StringBuilder()
-    reviewsHtml.append("<h1>Review Requests</h1><p>")
-    reviewsHtml.append(reviews)
-    reviewsHtml.append("</p>")
-    call.respondText(reviewsHtml.toString(), ContentType.Text.Html, HttpStatusCode.OK)
+    call.respondText(StringBuilder().apply {
+        append("<h1>Review Requests</h1><p>")
+        append(reviews)
+        append("</p>")
+    }.toString(), ContentType.Text.Html, HttpStatusCode.OK)
 }
 
 /**
@@ -246,7 +246,7 @@ suspend fun installGet(call: ApplicationCall) {
         slackAuth?.incomingWebhook?.let { webhook ->
             if (webhook.channel == Config.ADMIN_CHANNEL) {
                 // TODO Should this be the only place to configure Admin Channel?
-                Config.SLACK_ADMIN_URL = webhook.url
+                Config.ADMIN_URL = webhook.url
                 val config = Config.configData
                 // TODO Should there be specific setters?
                 Config.configData = ConfigData(

--- a/backend/src/main/kotlin/com/hootsuite/hermes/database/DatabaseUtils.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/database/DatabaseUtils.kt
@@ -52,17 +52,12 @@ object DatabaseUtils {
     fun getSlackUserOrNull(githubName: String): SlackUser? = transaction {
         val user = UserEntity.find { Users.githubName eq githubName }.firstOrNull()
         if (user == null) {
-            SlackMessageHandler.missingUser(githubName, Config.SLACK_ADMIN_URL)
+            SlackMessageHandler.onMissingUser(githubName, Config.ADMIN_URL)
             null
         } else {
             val team = TeamEntity.find { Teams.teamName eq user.teamName }.firstOrNull()
             if (team == null) {
-                SlackMessageHandler.missingTeam(
-                    user.githubName,
-                    user.slackName,
-                    user.teamName,
-                    Config.SLACK_ADMIN_URL
-                )
+                SlackMessageHandler.onMissingTeam(user.githubName, user.slackName, user.teamName, Config.ADMIN_URL)
                 null
             } else {
                 // TODO Where should we handle '@'? Currently it's on registration
@@ -85,12 +80,12 @@ object DatabaseUtils {
                 existingUser.slackName = formatSlackHandle(user.slackName)
                 existingUser.teamName = user.teamName
                 existingUser.avatarUrl = user.avatarUrl
-                SlackMessageHandler.updateUser(
+                SlackMessageHandler.onUpdateUser(
                     user.githubName,
                     user.slackName,
                     user.teamName,
                     user.avatarUrl,
-                    Config.SLACK_ADMIN_URL
+                    Config.ADMIN_URL
                 )
             } else {
                 UserEntity.new {
@@ -99,12 +94,12 @@ object DatabaseUtils {
                     teamName = user.teamName
                     avatarUrl = user.avatarUrl
                 }
-                SlackMessageHandler.createUser(
+                SlackMessageHandler.onCreateUser(
                     user.githubName,
                     user.slackName,
                     user.teamName,
                     user.avatarUrl,
-                    Config.SLACK_ADMIN_URL
+                    Config.ADMIN_URL
                 )
             }
         }
@@ -121,20 +116,20 @@ object DatabaseUtils {
             val existingTeam = TeamEntity.find { Teams.teamName eq team.teamName }.firstOrNull()
             if (existingTeam != null) {
                 existingTeam.slackUrl = team.slackUrl
-                SlackMessageHandler.updateTeam(
+                SlackMessageHandler.onUpdateTeam(
                     team.teamName,
                     team.slackUrl,
-                    Config.SLACK_ADMIN_URL
+                    Config.ADMIN_URL
                 )
             } else {
                 TeamEntity.new {
                     teamName = team.teamName
                     slackUrl = team.slackUrl
                 }
-                SlackMessageHandler.createTeam(
+                SlackMessageHandler.onCreateTeam(
                     team.teamName,
                     team.slackUrl,
-                    Config.SLACK_ADMIN_URL
+                    Config.ADMIN_URL
                 )
             }
         }

--- a/backend/src/main/kotlin/com/hootsuite/hermes/database/model/Entities.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/database/model/Entities.kt
@@ -55,3 +55,21 @@ class ReviewRequestEntity(id: EntityID<Int>) : IntEntity(id) {
 
     companion object : IntEntityClass<ReviewRequestEntity>(ReviewRequests)
 }
+
+/**
+ * Hermes Reviews DAO
+ */
+class ReviewEntity(id: EntityID<Int>) : IntEntity(id) {
+
+    var githubName by Reviews.githubName
+    var htmlUrl by Reviews.htmlUrl
+    var reviewState by Reviews.reviewState
+
+    /**
+     * Format for viewing as a single String
+     * TODO Fix This
+     */
+    override fun toString() = "$githubName : $htmlUrl : $reviewState"
+
+    companion object : IntEntityClass<ReviewEntity>(Reviews)
+}

--- a/backend/src/main/kotlin/com/hootsuite/hermes/database/model/Tables.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/database/model/Tables.kt
@@ -28,3 +28,12 @@ object ReviewRequests : IntIdTable() {
     val htmlUrl = varchar("htmlUrl", 150).index()
     val githubName = varchar("githubName", 50)
 }
+
+/**
+ * Reviews Table
+ */
+object Reviews : IntIdTable() {
+    val githubName = varchar("githubName", 50).index()
+    val htmlUrl = varchar("htmlUrl", 150)
+    val reviewState = varchar("reviewState", 50)
+}

--- a/backend/src/main/kotlin/com/hootsuite/hermes/github/model/Events.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/github/model/Events.kt
@@ -7,7 +7,6 @@ import com.google.gson.annotations.SerializedName
  */
 object Events {
 
-    // Event Header
     const val EVENT_HEADER = "X-GitHub-Event"
 
     const val NO_EVENT = "NO_EVENT"
@@ -52,7 +51,8 @@ data class PullRequestReviewEvent(
     val action: PullRequestReviewAction,
     val review: Review,
     @SerializedName("pull_request")
-    val pullRequest: PullRequest
+    val pullRequest: PullRequest,
+    val sender: User
 )
 
 /**

--- a/backend/src/main/kotlin/com/hootsuite/hermes/model/Dto.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/model/Dto.kt
@@ -22,6 +22,44 @@ data class Team(
  * DTO Object for a Hermes Review Request
  */
 data class ReviewRequest(
-    var htmlUrl: String,
-    var githubName: String
+    val htmlUrl: String,
+    val githubName: String
 )
+
+/**
+ * DTO Object for a Hermes Review
+ */
+class Review private constructor(
+    val githubName: String,
+    val htmlUrl: String,
+    val reviewState: ReviewState
+) {
+    companion object {
+        /**
+         * Builder method for Approved Review
+         * @param name - The Github name of the reviewer
+         * @param htmlUrl - The htmlUrl of the Pull Request
+         */
+        fun approved(name: String, htmlUrl: String) = Review(name, htmlUrl, ReviewState.APPROVED)
+
+        /**
+         * Builder method for Commented Review
+         * @param name - The Github name of the reviewer
+         * @param htmlUrl - The htmlUrl of the Pull Request
+         */
+        fun commented(name: String, htmlUrl: String) = Review(name, htmlUrl, ReviewState.COMMENTED)
+
+        /**
+         * Builder method for Changes Requested Review
+         * @param name - The Github name of the reviewer
+         * @param htmlUrl - The htmlUrl of the Pull Request
+         */
+        fun changesRequested(name: String, htmlUrl: String) = Review(name, htmlUrl, ReviewState.CHANGES_REQUESTED)
+    }
+}
+
+enum class ReviewState {
+    APPROVED,
+    COMMENTED,
+    CHANGES_REQUESTED
+}

--- a/backend/src/main/kotlin/com/hootsuite/hermes/slack/SlackMessageHandler.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/slack/SlackMessageHandler.kt
@@ -7,7 +7,6 @@ import com.hootsuite.hermes.slack.model.SlackUser
 
 /**
  * Object to handle sending various messages to Slack
- * TODO Organize the methods
  */
 object SlackMessageHandler {
 
@@ -34,7 +33,7 @@ object SlackMessageHandler {
      * @param author - The Author of the Pull Request
      * @param url - The http URL of the Pull Request
      */
-    fun approved(reviewer: String, author: SlackUser, url: String) {
+    fun onApproved(reviewer: String, author: SlackUser, url: String) {
         val params = SlackParams.approved(reviewer, author.name, url, author.avatarUrl)
         sendToSlack(author.slackUrl, params)
     }
@@ -46,7 +45,7 @@ object SlackMessageHandler {
      * @param url - The http URL of the Pull Request
      * @param comment - Review
      */
-    fun changesRequested(reviewer: String, author: SlackUser, url: String, comment: String) {
+    fun onChangesRequested(reviewer: String, author: SlackUser, url: String, comment: String) {
         val params = SlackParams.changesRequested(reviewer, author.name, url, comment, author.avatarUrl)
         sendToSlack(author.slackUrl, params)
     }
@@ -58,7 +57,7 @@ object SlackMessageHandler {
      * @param url - The http URL of the Pull Request
      * @param comment - Review
      */
-    fun commented(reviewer: String, author: SlackUser, url: String, comment: String) {
+    fun onCommented(reviewer: String, author: SlackUser, url: String, comment: String) {
         val params = SlackParams.commented(reviewer, author.name, url, comment, author.avatarUrl)
         sendToSlack(author.slackUrl, params)
     }
@@ -69,7 +68,7 @@ object SlackMessageHandler {
      * @param reviewer - The Author of the review which has been dismissed
      * @param url - The http URL of the Pull Request
      */
-    fun reviewDismissed(dismisser: String, reviewer: SlackUser, url: String) {
+    fun onReviewDismissed(dismisser: String, reviewer: SlackUser, url: String) {
         val params = SlackParams.reviewDismissed(dismisser, reviewer.name, url, reviewer.avatarUrl)
         sendToSlack(reviewer.slackUrl, params)
     }
@@ -82,7 +81,7 @@ object SlackMessageHandler {
      * @param url - The http URL of the Pull Request
      * @param title - The title of the Pull Request
      */
-    fun requestReviewer(reviewer: SlackUser, author: String, sender: String?, url: String, title: String) {
+    fun onRequestReviewer(reviewer: SlackUser, author: String, sender: String?, url: String, title: String) {
         val params = SlackParams.requestReviewer(
             reviewer.name, author, sender, url, title, reviewer.avatarUrl
         )
@@ -95,7 +94,7 @@ object SlackMessageHandler {
      * @param author - The Author of the Pull Request
      * @param url - The http URL of the Pull Request
      */
-    fun rerequestReviewer(reviewer: SlackUser, author: String, url: String) {
+    fun onRerequestReviewer(reviewer: SlackUser, author: String, url: String) {
         val params = SlackParams.rerequestReviewer(reviewer.name, author, url, reviewer.avatarUrl)
         sendToSlack(reviewer.slackUrl, params)
     }
@@ -106,7 +105,7 @@ object SlackMessageHandler {
      * @param issueUrl - The URL of the Pull Request
      * @param arguments - The list of arguments passed to the rereview command which could not be parsed
      */
-    fun unhandledRereview(commenter: SlackUser, issueUrl: String, arguments: String) {
+    fun onUnhandledRereview(commenter: SlackUser, issueUrl: String, arguments: String) {
         val params = SlackParams.unhandledReview(commenter.name, issueUrl, arguments, commenter.avatarUrl)
         sendToSlack(commenter.slackUrl, params)
     }
@@ -118,7 +117,7 @@ object SlackMessageHandler {
      * @param repoName - The full repo name (Org and Repo) with the failing commit
      * @param commitUrl - The Html URL of the failing commit
      */
-    fun buildFailure(author: SlackUser, targetUrl: String, repoName: String, commitUrl: String) {
+    fun onBuildFailure(author: SlackUser, targetUrl: String, repoName: String, commitUrl: String) {
         val params = SlackParams.buildFailure(author.name, targetUrl, repoName, commitUrl, author.avatarUrl)
         sendToSlack(author.slackUrl, params)
     }
@@ -133,7 +132,7 @@ object SlackMessageHandler {
      * @param adminUrl - The slack URL to send the status message to
      * @param avatarUrl - The Url of the avatar of the user or null if there is no avatar
      */
-    fun createUser(githubName: String, slackName: String, teamName: String, avatarUrl: String?, adminUrl: String) {
+    fun onCreateUser(githubName: String, slackName: String, teamName: String, avatarUrl: String?, adminUrl: String) {
         val params = SlackParams.createUser(githubName, slackName, teamName, avatarUrl)
         sendToSlack(adminUrl, params)
     }
@@ -146,7 +145,7 @@ object SlackMessageHandler {
      * @param adminUrl - The slack URL to send the status message to
      * @param avatarUrl - The Url of the avatar of the user or null if there is no avatar
      */
-    fun updateUser(githubName: String, slackName: String, teamName: String, avatarUrl: String?, adminUrl: String) {
+    fun onUpdateUser(githubName: String, slackName: String, teamName: String, avatarUrl: String?, adminUrl: String) {
         val params = SlackParams.updateUser(githubName, slackName, teamName, avatarUrl)
         sendToSlack(adminUrl, params)
     }
@@ -157,7 +156,7 @@ object SlackMessageHandler {
      * @param slackUrl - The slack webhook url of the team
      * @param adminUrl - The slack URL to send the status message to
      */
-    fun createTeam(teamName: String, slackUrl: String, adminUrl: String) {
+    fun onCreateTeam(teamName: String, slackUrl: String, adminUrl: String) {
         val params = SlackParams.createTeam(teamName, slackUrl)
         sendToSlack(adminUrl, params)
     }
@@ -168,7 +167,7 @@ object SlackMessageHandler {
      * @param slackUrl - The slack webhook url of the team
      * @param adminUrl - The slack URL to send the status message to
      */
-    fun updateTeam(teamName: String, slackUrl: String, adminUrl: String) {
+    fun onUpdateTeam(teamName: String, slackUrl: String, adminUrl: String) {
         val params = SlackParams.updateTeam(teamName, slackUrl)
         sendToSlack(adminUrl, params)
     }
@@ -178,7 +177,7 @@ object SlackMessageHandler {
      * @param githubName - The Github name of the missing user
      * @param adminUrl - The slack URL to send the status message to
      */
-    fun missingUser(githubName: String, adminUrl: String) {
+    fun onMissingUser(githubName: String, adminUrl: String) {
         val params = SlackParams.missingUser(githubName)
         sendToSlack(adminUrl, params)
     }
@@ -190,7 +189,7 @@ object SlackMessageHandler {
      * @param teamName - The Hermes team name which is missing
      * @param adminUrl - The slack URL to send the status message to
      */
-    fun missingTeam(githubName: String, slackName: String, teamName: String, adminUrl: String) {
+    fun onMissingTeam(githubName: String, slackName: String, teamName: String, adminUrl: String) {
         val params = SlackParams.missingTeam(githubName, slackName, teamName)
         sendToSlack(adminUrl, params)
     }
@@ -201,7 +200,7 @@ object SlackMessageHandler {
      * @param eventName - The name of the Unhandled Github event
      * @param adminUrl - The slack RUL to send the status message to
      */
-    fun unhandledEvent(eventName: String, adminUrl: String) {
+    fun onUnhandledEvent(eventName: String, adminUrl: String) {
         val params = SlackParams.unhandledEvent(eventName)
         sendToSlack(adminUrl, params)
     }
@@ -215,7 +214,7 @@ object SlackMessageHandler {
      * @param sender - The person who configured the webhook
      * @param adminUrl - The Admin URL to send the message to
      */
-    fun ping(
+    fun onPing(
         zen: String,
         missingEvents: List<String>,
         extraEvents: List<String>,

--- a/backend/src/main/kotlin/com/hootsuite/hermes/slack/SlackMessageHandler.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/slack/SlackMessageHandler.kt
@@ -34,8 +34,8 @@ object SlackMessageHandler {
      * @param author - The Author of the Pull Request
      * @param url - The http URL of the Pull Request
      */
-    fun approval(reviewer: String, author: SlackUser, url: String) {
-        val params = SlackParams.approval(reviewer, author.name, url, author.avatarUrl)
+    fun approved(reviewer: String, author: SlackUser, url: String) {
+        val params = SlackParams.approved(reviewer, author.name, url, author.avatarUrl)
         sendToSlack(author.slackUrl, params)
     }
 
@@ -46,9 +46,32 @@ object SlackMessageHandler {
      * @param url - The http URL of the Pull Request
      * @param comment - Review
      */
-    fun requestChanges(reviewer: String, author: SlackUser, url: String, comment: String) {
-        val params = SlackParams.requestChanges(reviewer, author.name, url, comment, author.avatarUrl)
+    fun changesRequested(reviewer: String, author: SlackUser, url: String, comment: String) {
+        val params = SlackParams.changesRequested(reviewer, author.name, url, comment, author.avatarUrl)
         sendToSlack(author.slackUrl, params)
+    }
+
+    /**
+     * Send a Pull Request Commented Message to Slack
+     * @param reviewer - The Reviewer of the Pull Request
+     * @param author - The Author of the Pull Request
+     * @param url - The http URL of the Pull Request
+     * @param comment - Review
+     */
+    fun commented(reviewer: String, author: SlackUser, url: String, comment: String) {
+        val params = SlackParams.commented(reviewer, author.name, url, comment, author.avatarUrl)
+        sendToSlack(author.slackUrl, params)
+    }
+
+    /**
+     * Send a Pull Request Commented Message to Slack
+     * @param dismisser - The github user who dismissed the Pull Request review
+     * @param reviewer - The Author of the review which has been dismissed
+     * @param url - The http URL of the Pull Request
+     */
+    fun reviewDismissed(dismisser: String, reviewer: SlackUser, url: String) {
+        val params = SlackParams.reviewDismissed(dismisser, reviewer.name, url, reviewer.avatarUrl)
+        sendToSlack(reviewer.slackUrl, params)
     }
 
     /**
@@ -61,12 +84,7 @@ object SlackMessageHandler {
      */
     fun requestReviewer(reviewer: SlackUser, author: String, sender: String?, url: String, title: String) {
         val params = SlackParams.requestReviewer(
-            reviewer.name,
-            author,
-            sender,
-            url,
-            title,
-            reviewer.avatarUrl
+            reviewer.name, author, sender, url, title, reviewer.avatarUrl
         )
         sendToSlack(reviewer.slackUrl, params)
     }
@@ -80,6 +98,17 @@ object SlackMessageHandler {
     fun rerequestReviewer(reviewer: SlackUser, author: String, url: String) {
         val params = SlackParams.rerequestReviewer(reviewer.name, author, url, reviewer.avatarUrl)
         sendToSlack(reviewer.slackUrl, params)
+    }
+
+    /**
+     * Send a unhandled Rereveiew event message to slack
+     * @param commenter - The user who made the unhandled rereview event in github
+     * @param issueUrl - The URL of the Pull Request
+     * @param arguments - The list of arguments passed to the rereview command which could not be parsed
+     */
+    fun unhandledRereview(commenter: SlackUser, issueUrl: String, arguments: String) {
+        val params = SlackParams.unhandledReview(commenter.name, issueUrl, arguments, commenter.avatarUrl)
+        sendToSlack(commenter.slackUrl, params)
     }
 
     /**

--- a/backend/src/main/kotlin/com/hootsuite/hermes/slack/model/SlackParams.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/slack/model/SlackParams.kt
@@ -24,7 +24,7 @@ data class SlackParams(
          * @param avatarUrl - The Url of the avatar of the user or null if there is no avatar
          * @return SlackParams - The params of the formatted slack message
          */
-        fun approval(reviewer: String, author: String, url: String, avatarUrl: String?) = SlackParams(
+        fun approved(reviewer: String, author: String, url: String, avatarUrl: String?) = SlackParams(
             iconEmoji = ":thumbsup:",
             attachments = arrayOf(
                 Attachment(
@@ -49,22 +49,66 @@ data class SlackParams(
          * @param avatarUrl - The Url of the avatar of the user or null if there is no avatar
          * @return SlackParams - The params of the formatted slack message
          */
-        fun requestChanges(
-            reviewer: String,
-            author: String,
-            url: String,
-            comment: String,
-            avatarUrl: String?
-        ) = SlackParams(
-            iconEmoji = ":no_entry:",
+        fun changesRequested(reviewer: String, author: String, url: String, comment: String, avatarUrl: String?) =
+            SlackParams(
+                iconEmoji = ":no_entry:",
+                attachments = arrayOf(
+                    Attachment(
+                        fallback = "$reviewer - Changes Requested for $author.",
+                        color = "danger",
+                        author_name = reviewer,
+                        title = "PR Changes Requested: ${formatUrl(url)}",
+                        title_link = url,
+                        text = "<$author>, changes have been requested to your PR.\n$comment",
+                        thumb_url = avatarUrl
+                    )
+                ),
+                linkNames = 1
+            )
+
+        /**
+         * Format a Pull Request Commented Message for Slack
+         * @param reviewer - The Reviewer of the Pull Request
+         * @param author - The Author of the Pull Request
+         * @param url - The http URL of the Pull Request
+         * @param comment - The comment on the Review
+         * @param avatarUrl - The Url of the avatar of the user or null if there is no avatar
+         * @return SlackParams - The params of the formatted slack message
+         */
+        fun commented(reviewer: String, author: String, url: String, comment: String, avatarUrl: String?) = SlackParams(
+            iconEmoji = ":eyes:",
             attachments = arrayOf(
                 Attachment(
-                    fallback = "$reviewer - Changes Requested for $author.",
-                    color = "danger",
+                    fallback = "$reviewer - Comments left for $author.",
+                    color = "warning",
                     author_name = reviewer,
-                    title = "PR Changes Requested: ${formatUrl(url)}",
+                    title = "PR Commented: ${formatUrl(url)}",
                     title_link = url,
-                    text = "<$author>, changes have been requested to your PR.\n$comment",
+                    text = "<$author>, comments have been left on your PR.\n$comment",
+                    thumb_url = avatarUrl
+                )
+            ),
+            linkNames = 1
+        )
+
+        /**
+         * Format a Pull Request Commented Message for Slack
+         * @param dismisser - The person who dismissed the Pull Request Review
+         * @param reviewer - The Author of the Pull Request Review
+         * @param url - The http URL of the Pull Request
+         * @param avatarUrl - The Url of the avatar of the user or null if there is no avatar
+         * @return SlackParams - The params of the formatted slack message
+         */
+        fun reviewDismissed(dismisser: String, reviewer: String, url: String, avatarUrl: String?) = SlackParams (
+            iconEmoji = ":cyclone:",
+            attachments = arrayOf(
+                Attachment(
+                    fallback = "$reviewer: $dismisser has dismissed your Pull Request.",
+                    color = "warning",
+                    author_name = dismisser,
+                    title = "Review Dismissed: ${formatUrl(url)}",
+                    title_link = url,
+                    text = "<$reviewer>, one of your reviews have been dismissed by $dismisser.",
                     thumb_url = avatarUrl
                 )
             ),
@@ -120,6 +164,21 @@ data class SlackParams(
                     title = "Please take another look: ${formatUrl(url)}",
                     title_link = url,
                     text = "<$reviewer>: $author has requested another look at the Pull Request.",
+                    thumb_url = avatarUrl
+                )
+            ),
+            linkNames = 1
+        )
+
+        fun unhandledReview(commenter: String, url: String, arguments: String, avatarUrl: String?) = SlackParams(
+            attachments = arrayOf(
+                Attachment(
+                    fallback = "$commenter: Your rereview command failed.",
+                    color = "warning",
+                    author_name = commenter,
+                    title = "Your rereview command failed: ${formatUrl(url)}",
+                    title_link = url,
+                    text = "<$commenter>: Please use /help rereview to see accepted arguments\nYou tried: $arguments",
                     thumb_url = avatarUrl
                 )
             ),

--- a/backend/src/main/kotlin/com/hootsuite/hermes/slack/model/SlackParams.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/slack/model/SlackParams.kt
@@ -99,7 +99,7 @@ data class SlackParams(
          * @param avatarUrl - The Url of the avatar of the user or null if there is no avatar
          * @return SlackParams - The params of the formatted slack message
          */
-        fun reviewDismissed(dismisser: String, reviewer: String, url: String, avatarUrl: String?) = SlackParams (
+        fun reviewDismissed(dismisser: String, reviewer: String, url: String, avatarUrl: String?) = SlackParams(
             iconEmoji = ":cyclone:",
             attachments = arrayOf(
                 Attachment(


### PR DESCRIPTION
* Updated the README to reflect recently added features and add other features
* Adding a Reviews table, dao, and model. This will allow the tracking of PR reviews without having to authenticate to the github api to get them. With the new reviews table, allow the user to use `!hermes rejected` to notify anyone who has rejected the PR and `!hermes unapproved` to notify anyone who has not yet approved the PR.
* I noticed that some people prefer to comment on a PR before approving rather than explicitly requesting changes, the PR author will now get notified when a reviewer submits a "COMMENTED" state review.  

Fixed: Now correctly attributing `!hermes` commands in slack. (Previously always attributed to PR author)