### PR TITLE
Adding the ability to unregister through slack

### DIFF
--- a/backend/src/main/kotlin/com/hootsuite/hermes/Main.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/Main.kt
@@ -136,7 +136,7 @@ suspend fun usersGet(call: ApplicationCall) {
  */
 suspend fun usersPost(call: ApplicationCall) {
     val user = call.receive<User>()
-    DatabaseUtils.createOrUpdateUser(user)
+    DatabaseUtils.createOrUpdateUserByGithubName(user)
     //TODO Handle problems and Response
 }
 
@@ -162,7 +162,7 @@ suspend fun registerUserGet(call: ApplicationCall) {
         return
     }
     val avatarUrl = if (call.parameters["avatarUrl"].isNullOrEmpty()) null else call.parameters["avatarUrl"]
-    DatabaseUtils.createOrUpdateUser(User(githubName, slackName, teamName, avatarUrl))
+    DatabaseUtils.createOrUpdateUserByGithubName(User(githubName, slackName, teamName, avatarUrl))
     // TODO Handle Problems
     call.respondText("User Created or Updated Successfully", ContentType.Text.Plain, HttpStatusCode.OK)
 }

--- a/backend/src/main/kotlin/com/hootsuite/hermes/database/DatabaseUtils.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/database/DatabaseUtils.kt
@@ -110,41 +110,6 @@ object DatabaseUtils {
     }
 
     /**
-     * Create or update a User in the Database keyed on a User's Slack Handle
-     * @param user - The User Model Object to be stored
-     */
-    fun createOrUpdateUserBySlackHandle(user: User) = transaction {
-        val formattedHandle = formatSlackHandle(user.slackName)
-        val existingUser = UserEntity.find { Users.slackName eq formattedHandle }.firstOrNull()
-        if (existingUser != null) {
-            existingUser.slackName = formattedHandle
-            existingUser.teamName = user.teamName
-            existingUser.avatarUrl = user.avatarUrl
-            SlackMessageHandler.onUpdateUser(
-                user.githubName,
-                user.slackName,
-                user.teamName,
-                user.avatarUrl,
-                Config.ADMIN_URL
-            )
-        } else {
-            UserEntity.new {
-                githubName = user.githubName
-                slackName = formattedHandle
-                teamName = user.teamName
-                avatarUrl = user.avatarUrl
-            }
-            SlackMessageHandler.onCreateUser(
-                user.githubName,
-                user.slackName,
-                user.teamName,
-                user.avatarUrl,
-                Config.ADMIN_URL
-            )
-        }
-    }
-
-    /**
      * Delete Users for the given Slack Handle from the database
      * @param slackHandle - The Slack Handle of the User to be deleted
      */

--- a/backend/src/main/kotlin/com/hootsuite/hermes/database/DatabaseUtils.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/database/DatabaseUtils.kt
@@ -76,12 +76,10 @@ object DatabaseUtils {
         transaction { TeamEntity.find { Teams.teamName eq team }.firstOrNull() }
 
     /**
-     * Create or update a User in the Database
-     * TODO Handle Problems storing
+     * Create or update a User in the Database keyed on a User's Github Name
      * @param user - The User Model Object to be stored
      */
-    fun createOrUpdateUser(user: User) = transaction {
-        // TODO Extract and make multiple transactions
+    fun createOrUpdateUserByGithubName(user: User) = transaction {
         val existingUser = UserEntity.find { Users.githubName eq user.githubName }.firstOrNull()
         if (existingUser != null) {
             existingUser.slackName = formatSlackHandle(user.slackName)
@@ -112,6 +110,51 @@ object DatabaseUtils {
     }
 
     /**
+     * Create or update a User in the Database keyed on a User's Slack Handle
+     * @param user - The User Model Object to be stored
+     */
+    fun createOrUpdateUserBySlackHandle(user: User) = transaction {
+        val formattedHandle = formatSlackHandle(user.slackName)
+        val existingUser = UserEntity.find { Users.slackName eq formattedHandle }.firstOrNull()
+        if (existingUser != null) {
+            existingUser.slackName = formattedHandle
+            existingUser.teamName = user.teamName
+            existingUser.avatarUrl = user.avatarUrl
+            SlackMessageHandler.onUpdateUser(
+                user.githubName,
+                user.slackName,
+                user.teamName,
+                user.avatarUrl,
+                Config.ADMIN_URL
+            )
+        } else {
+            UserEntity.new {
+                githubName = user.githubName
+                slackName = formattedHandle
+                teamName = user.teamName
+                avatarUrl = user.avatarUrl
+            }
+            SlackMessageHandler.onCreateUser(
+                user.githubName,
+                user.slackName,
+                user.teamName,
+                user.avatarUrl,
+                Config.ADMIN_URL
+            )
+        }
+    }
+
+    /**
+     * Delete Users for the given Slack Handle from the database
+     * @param slackHandle - The Slack Handle of the User to be deleted
+     */
+    fun deleteUsersBySlackHandle(slackHandle: String): Int = transaction {
+        val users = UserEntity.find { Users.slackName eq formatSlackHandle(slackHandle) }
+        users.forEach { it.delete() }
+        users.count()
+    }
+
+    /**
      * Update a Users Avatar based on a slack handle
      * @param slackHandle - The slack handle of the user (including the mention character)
      * @param avatarString - The string of the User's avatar
@@ -132,7 +175,6 @@ object DatabaseUtils {
 
     /**
      * Create or update a Team in the Database
-     * TODO Handle Problems storing
      * @param team - The Team Model Object to be stored
      */
     fun createOrUpdateTeam(team: Team) {
@@ -162,7 +204,6 @@ object DatabaseUtils {
 
     /**
      * Create or update a Review Request in the database
-     * TODO Handle Problems storing
      * @param request - The Review Request to be stored in the database
      */
     fun createOrUpdateReviewRequest(request: ReviewRequest) = transaction {
@@ -174,6 +215,10 @@ object DatabaseUtils {
         }
     }
 
+    /**
+     * Create or update a Review in the database
+     * @param review - The Review to be stored in the database
+     */
     fun createOrUpdateReview(review: Review) = transaction {
         val existingReview = ReviewEntity.find {
             (Reviews.htmlUrl eq review.htmlUrl).and(Reviews.githubName eq review.githubName)

--- a/backend/src/main/kotlin/com/hootsuite/hermes/slack/SlashCommandHandler.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/slack/SlashCommandHandler.kt
@@ -25,7 +25,7 @@ object SlashCommandHandler {
                     "#${slashCommand.channel}"
                 }
                 if (parameters.size == 1) {
-                    DatabaseUtils.createOrUpdateUserBySlackHandle(User(parameters.first(), slashCommand.username, team))
+                    DatabaseUtils.createOrUpdateUserByGithubName(User(parameters.first(), slashCommand.username, team))
                     if (DatabaseUtils.getTeamOrNull(team) != null) {
                         "You have successfully registered to $team"
                     } else {

--- a/backend/src/main/kotlin/com/hootsuite/hermes/slack/SlashCommandHandler.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/slack/SlashCommandHandler.kt
@@ -25,7 +25,7 @@ object SlashCommandHandler {
                     "#${slashCommand.channel}"
                 }
                 if (parameters.size == 1) {
-                    DatabaseUtils.createOrUpdateUser(User(parameters.first(), slashCommand.username, team))
+                    DatabaseUtils.createOrUpdateUserBySlackHandle(User(parameters.first(), slashCommand.username, team))
                     if (DatabaseUtils.getTeamOrNull(team) != null) {
                         "You have successfully registered to $team"
                     } else {
@@ -33,6 +33,17 @@ object SlashCommandHandler {
                     }
                 } else {
                     REGISTER_HELP
+                }
+            }
+            SlashCommand.UNREGISTER -> {
+                if (parameters.isEmpty()) {
+                    val count = DatabaseUtils.deleteUsersBySlackHandle(slashCommand.username)
+                    when (count) {
+                        0 -> "Cannot find a user for your slack handle, nothing to deregister"
+                        else -> "Successfully unregistered $count associated Github Users"
+                    }
+                } else {
+                    UNREGISTER_HELP
                 }
             }
             SlashCommand.AVATAR -> {
@@ -56,12 +67,14 @@ object SlashCommandHandler {
             }
         }
 
-    private val HELP_TEXT = """Please use one of the following slash commands:
-        ```/hermes register <your github username>
-        /hermes avatar <your chosen avatar URL>
-        /hermes reviews```""".trimIndent()
+    private val HELP_TEXT = """Please use one of the following slash commands:```/hermes register <your github username>
+        |/hermes unregister
+        |/hermes avatar <your chosen avatar URL>
+        |/hermes reviews```""".trimMargin()
 
     private const val REGISTER_HELP = "Register with your github username: `/hermes register <your github username>`"
+
+    private const val UNREGISTER_HELP = "Unregister associated github accounts: `/hermes unregister`"
 
     private const val AVATAR_UPDATED = "Your Avatar has been updated."
     private const val AVATAR_HELP = "Update your avatar with a URL: `/hermes avatar <your chosen avatar URL>`"

--- a/backend/src/main/kotlin/com/hootsuite/hermes/slack/model/Models.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/slack/model/Models.kt
@@ -55,6 +55,7 @@ data class SlashCommand(
 ) {
     companion object {
         const val REGISTER = "register"
+        const val UNREGISTER = "unregister"
         const val AVATAR = "avatar"
         const val REVIEWS = "reviews"
 


### PR DESCRIPTION
Adding a slash command to slack `/hermes unregister` to allow a user to remove the github accounts associated with their slack handle.

Also, creating a second user creation method to key off slack handle when registering through slack.