### PR TITLE
Make body of review a nullable string

### DIFF
--- a/backend/src/main/kotlin/com/hootsuite/hermes/github/model/Payloads.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/github/model/Payloads.kt
@@ -51,7 +51,7 @@ data class Repository(
 data class Review(
     val user: User,
     val state: ApprovalState,
-    val body: String
+    val body: String?
 )
 
 /**

--- a/backend/src/main/kotlin/com/hootsuite/hermes/slack/SlackMessageHandler.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/slack/SlackMessageHandler.kt
@@ -45,7 +45,7 @@ object SlackMessageHandler {
      * @param url - The http URL of the Pull Request
      * @param comment - Review
      */
-    fun onChangesRequested(reviewer: String, author: SlackUser, url: String, comment: String) {
+    fun onChangesRequested(reviewer: String, author: SlackUser, url: String, comment: String?) {
         val params = SlackParams.changesRequested(reviewer, author.name, url, comment, author.avatarUrl)
         sendToSlack(author.slackUrl, params)
     }
@@ -57,7 +57,7 @@ object SlackMessageHandler {
      * @param url - The http URL of the Pull Request
      * @param comment - Review
      */
-    fun onCommented(reviewer: String, author: SlackUser, url: String, comment: String) {
+    fun onCommented(reviewer: String, author: SlackUser, url: String, comment: String?) {
         val params = SlackParams.commented(reviewer, author.name, url, comment, author.avatarUrl)
         sendToSlack(author.slackUrl, params)
     }

--- a/backend/src/main/kotlin/com/hootsuite/hermes/slack/model/SlackParams.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/slack/model/SlackParams.kt
@@ -49,7 +49,7 @@ data class SlackParams(
          * @param avatarUrl - The Url of the avatar of the user or null if there is no avatar
          * @return SlackParams - The params of the formatted slack message
          */
-        fun changesRequested(reviewer: String, author: String, url: String, comment: String, avatarUrl: String?) =
+        fun changesRequested(reviewer: String, author: String, url: String, comment: String?, avatarUrl: String?) =
             SlackParams(
                 iconEmoji = ":no_entry:",
                 attachments = arrayOf(
@@ -75,21 +75,22 @@ data class SlackParams(
          * @param avatarUrl - The Url of the avatar of the user or null if there is no avatar
          * @return SlackParams - The params of the formatted slack message
          */
-        fun commented(reviewer: String, author: String, url: String, comment: String, avatarUrl: String?) = SlackParams(
-            iconEmoji = ":eyes:",
-            attachments = arrayOf(
-                Attachment(
-                    fallback = "$reviewer - Comments left for $author.",
-                    color = "warning",
-                    author_name = reviewer,
-                    title = "PR Commented: ${formatUrl(url)}",
-                    title_link = url,
-                    text = "<$author>, comments have been left on your PR.\n$comment",
-                    thumb_url = avatarUrl
-                )
-            ),
-            linkNames = 1
-        )
+        fun commented(reviewer: String, author: String, url: String, comment: String?, avatarUrl: String?) =
+            SlackParams(
+                iconEmoji = ":eyes:",
+                attachments = arrayOf(
+                    Attachment(
+                        fallback = "$reviewer - Comments left for $author.",
+                        color = "warning",
+                        author_name = reviewer,
+                        title = "PR Commented: ${formatUrl(url)}",
+                        title_link = url,
+                        text = "<$author>, comments have been left on your PR.\n$comment",
+                        thumb_url = avatarUrl
+                    )
+                ),
+                linkNames = 1
+            )
 
         /**
          * Format a Pull Request Commented Message for Slack


### PR DESCRIPTION
I noticed that in some webhooks, the body of a review is null:
`"body": null,`
This is a fix to allow for that case.