### PR TITLE
No notifications for auto-dismissal of review

### DIFF
--- a/backend/src/main/kotlin/com/hootsuite/hermes/github/GithubEventHandler.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/github/GithubEventHandler.kt
@@ -55,8 +55,11 @@ object GithubEventHandler {
                 }
                 PullRequestReviewAction.DISMISSED -> {
                     DatabaseUtils.deleteReview(prUrl, reviewer)
-                    DatabaseUtils.getSlackUserOrNull(reviewer)?.let { slackUser ->
-                        SlackMessageHandler.onReviewDismissed(reviewEvent.sender.login, slackUser, prUrl)
+                    val sender = reviewEvent.sender.login
+                    if (sender != reviewer) {
+                        DatabaseUtils.getSlackUserOrNull(reviewer)?.let { slackUser ->
+                            SlackMessageHandler.onReviewDismissed(sender, slackUser, prUrl)
+                        }
                     }
                 }
                 else -> {


### PR DESCRIPTION
I noticed that when a person dismissed their own review they would be notified in slack, only notify when the dismisser is not the reviewer.