### PR TITLE
Removing storing Commented state to only store approved/rejected

### DIFF
--- a/backend/src/main/kotlin/com/hootsuite/hermes/database/DatabaseUtils.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/database/DatabaseUtils.kt
@@ -189,7 +189,7 @@ object DatabaseUtils {
         val existingReview = ReviewEntity.find {
             (Reviews.htmlUrl eq review.htmlUrl).and(Reviews.githubName eq review.githubName)
         }.firstOrNull()
-        if (existingReview != null) {
+        if (existingReview != null && review.reviewState != ReviewState.COMMENTED) {
             existingReview.reviewState = review.reviewState.name
         } else {
             ReviewEntity.new {

--- a/backend/src/main/kotlin/com/hootsuite/hermes/slack/SlackMessageHandler.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/slack/SlackMessageHandler.kt
@@ -94,8 +94,8 @@ object SlackMessageHandler {
      * @param author - The Author of the Pull Request
      * @param url - The http URL of the Pull Request
      */
-    fun onRerequestReviewer(reviewer: SlackUser, author: String, url: String) {
-        val params = SlackParams.rerequestReviewer(reviewer.name, author, url, reviewer.avatarUrl)
+    fun onRerequestReviewer(reviewer: SlackUser, requester: String, author: String, url: String) {
+        val params = SlackParams.rerequestReviewer(reviewer.name, requester, author, url, reviewer.avatarUrl)
         sendToSlack(reviewer.slackUrl, params)
     }
 

--- a/backend/src/main/kotlin/com/hootsuite/hermes/slack/model/SlackParams.kt
+++ b/backend/src/main/kotlin/com/hootsuite/hermes/slack/model/SlackParams.kt
@@ -156,20 +156,21 @@ data class SlackParams(
          * @param avatarUrl - The Url of the avatar of the user or null if there is no avatar
          * @return SlackParams - The params of the formatted slack message
          */
-        fun rerequestReviewer(reviewer: String, author: String, url: String, avatarUrl: String?) = SlackParams(
-            attachments = arrayOf(
-                Attachment(
-                    fallback = "$reviewer: $author has updated their Pull Request.",
-                    color = "#439FE0",
-                    author_name = author,
-                    title = "Please take another look: ${formatUrl(url)}",
-                    title_link = url,
-                    text = "<$reviewer>: $author has requested another look at the Pull Request.",
-                    thumb_url = avatarUrl
-                )
-            ),
-            linkNames = 1
-        )
+        fun rerequestReviewer(reviewer: String, requester: String, author: String, url: String, avatarUrl: String?) =
+            SlackParams(
+                attachments = arrayOf(
+                    Attachment(
+                        fallback = "$reviewer: $author has updated their Pull Request.",
+                        color = "#439FE0",
+                        author_name = author,
+                        title = "Please take another look: ${formatUrl(url)}",
+                        title_link = url,
+                        text = "<$reviewer>: $requester has requested another look at the Pull Request.",
+                        thumb_url = avatarUrl
+                    )
+                ),
+                linkNames = 1
+            )
 
         fun unhandledReview(commenter: String, url: String, arguments: String, avatarUrl: String?) = SlackParams(
             attachments = arrayOf(


### PR DESCRIPTION
1. Removing the COMMENTED state in the database. This state was preventing the `!hermes rejected` from notifying rejectors who have since commented on the PR.

2. Adding a "requester" to the rereview command to show in Slack that a non-author is requesting another look at the PR.